### PR TITLE
dockerfile and instructions on how to use it

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,13 @@
+FROM maven:3.3-jdk-8
+RUN useradd cumulusrdf -d /usr/src/app -m -s /bin/bash
+ADD . /usr/src/app/
+RUN chown -R cumulusrdf:cumulusrdf /usr/src/app
+
+USER cumulusrdf
+WORKDIR /usr/src/app
+RUN mvn -DskipTests install -Pcassandra2x-cql-full-tp-index 
+WORKDIR cumulusrdf-web-module/
+
+EXPOSE 9090
+ENTRYPOINT ["mvn"]
+CMD ["farsandra:start", "cargo:run","-Pcassandra2x-cql-full-tp-index"]

--- a/README.md
+++ b/README.md
@@ -15,6 +15,17 @@ To use CumulusRDF for your project, see the [GettingStarted](GettingStarted) wik
 
 Please see our [Features](Features) as well as our [Roadmap](Roadmap) wiki page for further information. 
 
+## Quick start using docker
+If you have docker you can get up and running quickly by using the following commands.
+
+```
+$ git clone git@github.com:cumulusrdf/cumulusrdf.git
+$ docker build -t cumulusrdf .
+$ docker run -d --name cumulusrdf -p 9090:9090 cumulusrdf
+```
+
+CumulusRDF is now available on http://localhost:9090/cumulus
+
 ## Want to contribute?
 We welcome any kind of contribution to cumulusRDF. In particular, we have a developer mailing list. Feel free to sign up via the web interface or by emailing at cumulusrdf-dev-list+subscribe@googlegroups.com. 
 


### PR DESCRIPTION
A dockerfile based on the getting started instructions so people can test the latest cumulusrdf source without needing any build environment. 

Feel free to try it out before pulling: https://hub.docker.com/r/nvdk/cumulusrdf/

```
$ docker run --name cumulustest -it -p 9090:9090 nvdk/cumulusrdf
```